### PR TITLE
Change Java version check to allow major versions >= 16

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -25,8 +25,10 @@ public final class Main
     public static void main(String[] args)
     {
         final String version = System.getProperty("java.version");
+        final int majorVersion = Integer.parseInt(version.split("\\.")[0]);
         System.out.println("java version: " + version);
-        if (!version.startsWith("16.") && !version.startsWith("17.")) {
+        System.out.println("java major version: " + majorVersion);
+        if (majorVersion < 16) {
             System.err.println("J requires Java 16 or later.");
             System.exit(1);
         }


### PR DESCRIPTION
I wanted to report I can run J successfully on Linux (AlmaLinux 9) with Java 19, and I figured I'd contribute the hack that allowed me to do so for posterity.

Thanks for continuing to work on J, I enjoyed discovering yesterday that it was still being developed, and that antialiasing can be turned on :smiley: